### PR TITLE
fixed ID duplicate

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -191,7 +191,7 @@ function App() {
                       <div>
                         <input
                           type="text"
-                          id="name"
+                          id="year"
                           placeholder="YY"
                           maxLength={2}
                           className={`form-control w-full ${


### PR DESCRIPTION
Hey Bisola, 

Here is a fix for your duplicate IDs. 

Description:

Year input ID changed from 'name' to 'year' to avoid a duplicate ID for the name input field.